### PR TITLE
Fix spurious checksum mismatches with Python 3

### DIFF
--- a/ichk/check.py
+++ b/ichk/check.py
@@ -127,7 +127,7 @@ class ObjectChecker(object):
             if hsh.name == 'md5':
                 phy_checksum = hsh.digest()
             else:
-                phy_checksum = base64.b64encode(hsh.digest())
+                phy_checksum = base64.b64encode(hsh.digest()).decode('ascii')
             f.close()
 
         if phy_checksum != irods_checksum:


### PR DESCRIPTION
Running ichk with Python 3 resulted in spurious checksum
mismatches, because ichk tried to compare bytes to a
unicode string.

There's a different issue with legacy MD5 checksums. I'll submit a PR for fixing that one later.