### PR TITLE
Fix comparison MD5 checksums

### DIFF
--- a/ichk/check.py
+++ b/ichk/check.py
@@ -125,7 +125,7 @@ class ObjectChecker(object):
                     break
 
             if hsh.name == 'md5':
-                phy_checksum = hsh.digest()
+                phy_checksum = hsh.hexdigest()
             else:
                 phy_checksum = base64.b64encode(hsh.digest())
             f.close()


### PR DESCRIPTION
The way legacy MD5 checksum values were compared did not match
the way they are encoded in the iCAT database, as of iRODS 4.2.x.