### PR TITLE
Detect stale replicas in all modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ These status codes can be used to represent the result of the check:
 * NO CHECKSUM:  There is no checksum registered in the iRODS catalog. This implies that file sizes do match.
 * NO_LOCAL_REPLICA: No replica of data object present on server (only used for object list check)
 * NOT_FOUND: Object name not found in iRODS (only used for object list check)
-* REPLICA_IS_DIRTY: Replica is dirty / stale (only used for object list check)
+* REPLICA_IS_STALE : Replica is stale (i.e. out of date)
 
 
 The meaning of the fields in CSV output is:


### PR DESCRIPTION
It would be useful to have ichk detect stale replicas in all modes (resource mode, vault mode, object list mode), since repair scripts that use as ichk CSV files as input generally need to differentiate between good replicas and stale ones (for example, in order to determine whether there's a good replica of a data object on a server).