### PR TITLE
Attempting to make compatible with Python 2 again.

### DIFF
--- a/ichk/check.py
+++ b/ichk/check.py
@@ -4,12 +4,12 @@ from __future__ import print_function
 import sys
 import os
 import errno
-from enum import Enum
 from collections import namedtuple
 from itertools import chain
 import hashlib
 import base64
 from ichk.formatters import Formatter
+from ichk.enums import Status, ObjectType
 from irods.column import Like
 from irods.data_object import irods_dirname, irods_basename
 from irods.models import Resource, Collection, DataObject
@@ -17,28 +17,6 @@ import irods.exception as iexc
 
 CHUNK_SIZE = 8192
 PY2 = (sys.version_info.major == 2)
-
-class Status(Enum):
-    OK = 0
-    NOT_EXISTING = 1        # File registered in iRODS but not found in vault
-    NOT_REGISTERED = 2      # File found in vault but is not registered in iRODS
-    FILE_SIZE_MISMATCH = 3  # File sizes do not match between database and vault
-    CHECKSUM_MISMATCH = 4   # Checksums do not match between database and vault
-    ACCESS_DENIED = 5       # This script was denied access to the file
-    NO_CHECKSUM = 6         # iRODS has no checksum registered
-    NO_LOCAL_REPLICA = 7    # No replica of data object present on server (object list check)
-    NOT_FOUND = 8           # Object not found in iRODS (object list check)
-    REPLICA_IS_STALE = 9    # Replica is stale
-
-    def __repr__(self):
-        return self.name
-
-
-class ObjectType(Enum):
-    COLLECTION = 0
-    DATAOBJECT = 1
-    FILE = 2
-    DIRECTORY = 3
 
 Result = namedtuple('Result', 'obj_type obj_path phy_path status observed_values')
 

--- a/ichk/enums.py
+++ b/ichk/enums.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+
+class Status(Enum):
+    OK = 0
+    NOT_EXISTING = 1        # File registered in iRODS but not found in vault
+    NOT_REGISTERED = 2      # File found in vault but is not registered in iRODS
+    FILE_SIZE_MISMATCH = 3  # File sizes do not match between database and vault
+    CHECKSUM_MISMATCH = 4   # Checksums do not match between database and vault
+    ACCESS_DENIED = 5       # This script was denied access to the file
+    NO_CHECKSUM = 6         # iRODS has no checksum registered
+    NO_LOCAL_REPLICA = 7    # No replica of data object present on server (object list check)
+    NOT_FOUND = 8           # Object not found in iRODS (object list check)
+    REPLICA_IS_STALE = 9    # Replica is stale
+
+    def __repr__(self):
+        return self.name
+
+
+class ObjectType(Enum):
+    COLLECTION = 0
+    DATAOBJECT = 1
+    FILE = 2
+    DIRECTORY = 3
+

--- a/ichk/formatters.py
+++ b/ichk/formatters.py
@@ -1,7 +1,7 @@
 """Formatters for output of checks"""
 
 from __future__ import print_function
-from ichk import check
+from ichk.enums import Status
 import sys
 
 class Formatter(object):
@@ -57,11 +57,11 @@ Status: {status}"""
 
         values = result.observed_values
 
-        if result.status is check.Status.FILE_SIZE_MISMATCH:
+        if result.status is Status.FILE_SIZE_MISMATCH:
             printl("Expected size: " + str(values['expected_filesize']))
             printl("Observed size: " + str(values['observed_filesize']))
 
-        if result.status is check.Status.CHECKSUM_MISMATCH:
+        if result.status is Status.CHECKSUM_MISMATCH:
             printl("Expected checksum: " + values['expected_checksum'])
             printl("Observed checksum: " + values['observed_checksum'])
 


### PR DESCRIPTION
Hi, I followed the installation instructions on CentOS 7 using Python 2.7. However, I'm getting the following error. The problem does not occur with Python 3. It looks like the recursive import does not work and it would be better to pull the enums into their own module?

```
(irods-consistency-check) 0|0|sodar-irods-res-2 ~ # /opt/irods-consistency-check/bin/ichk
Traceback (most recent call last):
  File "/opt/irods-consistency-check/bin/ichk", line 11, in <module>
    load_entry_point('ichk==0.3.1', 'console_scripts', 'ichk')()
  File "/opt/irods-consistency-check/lib/python2.7/site-packages/pkg_resources/__init__.py", line 565, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/opt/irods-consistency-check/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
    return ep.load()
  File "/opt/irods-consistency-check/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2291, in load
    return self.resolve()
  File "/opt/irods-consistency-check/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2297, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/opt/irods-consistency-check/lib/python2.7/site-packages/ichk/command.py", line 8, in <module>
    from ichk import check
  File "/opt/irods-consistency-check/lib/python2.7/site-packages/ichk/check.py", line 12, in <module>
    from ichk.formatters import Formatter
  File "/opt/irods-consistency-check/lib/python2.7/site-packages/ichk/formatters.py", line 4, in <module>
    from ichk import check
ImportError: cannot import name check
```