### PR TITLE
All local resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ This user should also have access to the files in the vault path directly.
 
 The command line switches are displayed below:
 ```
-usage: ichk [-h] [-f FQDN] (-r RESOURCE | -v VAULT | -l DATA_OBJECT_LIST_FILE)
+usage: ichk [-h] [-f FQDN]
+            (-r RESOURCE | -v VAULT | -l DATA_OBJECT_LIST_FILE | --all-local-resources | --all-local-vaults)
             [-o OUTPUT] [-m {human,csv}] [-t TRUNCATE] [-T TIMEOUT]
             [-s ROOT_COLLECTION]
 
@@ -54,6 +55,10 @@ optional arguments:
   -l DATA_OBJECT_LIST_FILE, --data-object-list DATA_OBJECT_LIST_FILE
                         Check replicas of a list of data objects on this
                         server.
+  --all-local-resources
+                        Scan all unixfilesystem resources on this server
+  --all-local-vaults    Scan all vaults of unixfilesystem resources on this
+                        server
   -o OUTPUT, --output OUTPUT
                         Write output to file
   -m {human,csv}, --format {human,csv}
@@ -70,8 +75,11 @@ optional arguments:
 
 ```
 
-You need to supply either a resource, a vault path or a data object list.
+You need to supply either a resource, a vault path, a data object list, the --all-local-resources option
+or the --all-local-vaults option.
+
 The FQDN (fully qualified domain name) defaults to the FQDN of the current machine.
+
 When composable resources are used, the ichk command will scan for leaf resources starting from the given resource.
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ The meaning of the fields in CSV output is:
 6. Expected checksum value (field is empty for collections / directories, as well as for files / data objects with a size mismatch)
 7. Observed file size (field is empty for collections / directories)
 8. Expected file size (field is empty for collections / directories)
+9. Resource name

--- a/ichk/command.py
+++ b/ichk/command.py
@@ -25,6 +25,10 @@ def entry():
     scan_type.add_argument("-l", "--data-object-list", dest='data_object_list_file', default=None,
                            type=argparse.FileType('r'),
                            help="Check replicas of a list of data objects on this server.")
+    scan_type.add_argument("--all-local-resources", action="store_true", default=False,
+                           help="Scan all unixfilesystem resources on this server")
+    scan_type.add_argument("--all-local-vaults", action="store_true", default=False,
+                           help="Scan all vaults of unixfilesystem resources on this server")
     parser.add_argument("-o", "--output", type=argparse.FileType('w'),
                         help="Write output to file")
     parser.add_argument("-m", "--format", dest="fmt", default='human',
@@ -57,6 +61,7 @@ def entry():
     session.connection_timeout = args.timeout
 
     run(session, args)
+
 
 
 def setup_session():
@@ -100,10 +105,16 @@ def setup_session():
 def run(session, args):
     if args.resource:
         executor = check.ResourceCheck(
-            session, args.fqdn, args.resource, args.root_collection)
+            session, args.fqdn, args.resource, args.root_collection, False)
     elif args.vault:
         executor = check.VaultCheck(
-            session, args.fqdn, args.vault, args.root_collection)
+            session, args.fqdn, args.vault, args.root_collection, False)
+    elif args.all_local_resources:
+        executor = check.ResourceCheck(
+            session, args.fqdn, None, args.root_collection, True)
+    elif args.all_local_vaults:
+        executor = check.VaultCheck(
+            session, args.fqdn, None, args.root_collection, True)
     elif args.data_object_list_file:
         executor = check.ObjectListCheck(
             session, args.fqdn, args.data_object_list_file)

--- a/ichk/formatters.py
+++ b/ichk/formatters.py
@@ -25,6 +25,7 @@ class HumanFormatter(Formatter):
     options = ['truncate']
     template = """----
 Type: {obj_type}
+Resource: {resource}
 iRODS path: {obj_path}
 Physical path: {phy_path}
 Status: {status}"""
@@ -42,7 +43,15 @@ Status: {status}"""
 
     def __call__(self, result):
         obj_type = result.obj_type.name
+
+        if result.obj_type in (check.ObjectType.DATAOBJECT,
+                               check.ObjectType.FILE):
+            resource = result.resource
+        else:
+            resource = "N/A"
+
         status = result.status.name
+
         # python 2 format defaults to ASCII encoding, enforce UTF-8
         if self.PY2:
             obj_path = result.obj_path.encode('utf-8')
@@ -83,7 +92,7 @@ class CSVFormatter(Formatter):
     def head(self):
         self.writer.writerow(('Type', 'Status', 'iRODS Path', 'Physical Path',
                               'Observed checksum', 'Expected checksum',
-                              'Observed size', 'Expected size'))
+                              'Observed size', 'Expected size', 'Resource'))
 
     def __call__(self, result):
         if self.PY2:
@@ -94,6 +103,12 @@ class CSVFormatter(Formatter):
             obj_path = result.obj_path
             phy_path = result.phy_path
 
+        if result.obj_type in (check.ObjectType.DATAOBJECT,
+                               check.ObjectType.FILE):
+            resource = result.resource
+        else:
+            resource = ""
+
         self.writer.writerow(
             (result.obj_type.name,
              result.status.name,
@@ -102,4 +117,5 @@ class CSVFormatter(Formatter):
              result.observed_values.get('observed_checksum', ''),
              result.observed_values.get('expected_checksum', ''),
              str(result.observed_values.get('observed_filesize', '')),
-             str(result.observed_values.get('expected_filesize', ''))))
+             str(result.observed_values.get('expected_filesize', '')),
+             resource))


### PR DESCRIPTION
This adds a resource field to the output of ichk, and adds options for scanning either all local resources or all local vaults. 

This feature is mainly useful when ichk data serves as input for repair scripts. It is also convenient for regular application administration, since we often need to scan all local resources on a server, rather than just one specific resource.

I will release a new major version of ichk after this PR has been merged, since it changes the output format.