### PR TITLE
YDA-4873: add support for S3 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ It can run in three modes:
   replicas of these data objects. This mode can be used to check whether an iRODS server has valid replicas
   of a particular set of data objects.
 
+Resource mode and object list mode support both unixfilesystem (UFS) and S3 resources. Vault mode currently only supports
+unixfilesystem resources.
+
 Ichk can use either a human-readable output format, or comma-separated values (CSV).
 
 ## Requirements
@@ -103,6 +106,7 @@ These status codes can be used to represent the result of the check:
 * `NO_LOCAL_REPLICA`: No replica of data object present on server (only used for object list check)
 * `NOT_FOUND`: Object name not found in iRODS (only used for object list check)
 * `REPLICA_NOT_GOOD` : Replica has a state other than good in the iCAT database (e.g. stale)
+* `UNKNOWN` : unable to verify (e.g. collections on a S3 resource)
 
 
 The meaning of the fields in CSV output is:

--- a/ichk/resource_interface.py
+++ b/ichk/resource_interface.py
@@ -1,0 +1,15 @@
+class ResourceInterface:
+    def check_object_exists(self, path):
+        raise Exception("Not implemented")
+
+
+    def check_coll_exists(self, path):
+        raise Exception("Not implemented")
+
+
+    def get_size(self, path):
+        raise Exception("Not implemented")
+
+
+    def get_checksum(self, path, checksumtype):
+        raise Exception("Not implemented")

--- a/ichk/resource_interface_factory.py
+++ b/ichk/resource_interface_factory.py
@@ -1,0 +1,39 @@
+from irods.models import Resource
+import irods.exception as iexc
+
+from ichk.s3_resource_interface import S3ResourceInterface
+from ichk.ufs_resource_interface import UFSResourceInterface
+
+
+class ResourceInterfaceFactory:
+    def __init__(self, session):
+        self.resource_interface_cache = dict()
+        self.session = session
+
+
+    def get_resource_interface(self, resource_name):
+        if resource_name in self.resource_interface_cache:
+            return self.resource_interface_cache.get(resource_name)
+
+        resource_type = self._get_resource_type(resource_name)
+        if resource_type  == "unixfilesystem":
+            result = UFSResourceInterface()
+            self.resource_interface_cache[resource_name] = result
+            return result
+        elif resource_type == "s3":
+            result = S3ResourceInterface(self.session, resource_name)
+            self.resource_interface_cache[resource_name] = result
+            return result
+        elif resource_type is None:
+            return None
+        else:
+            raise ValueError(f"Resource type {resource_type} not supported.")
+
+
+    def _get_resource_type(self, resource_name):
+        try:
+            resource = self.session.query(Resource).filter(
+                Resource.name == resource_name).one()
+        except iexc.NoResultFound:
+            return None
+        return resource[Resource.type]

--- a/ichk/s3_resource_interface.py
+++ b/ichk/s3_resource_interface.py
@@ -21,10 +21,12 @@ class S3ResourceInterface(ResourceInterface):
         self.s3_hostname = self._get_s3_hostname(resource_name)
         (self.s3_accesskey, self.s3_secretkey) = self._get_s3_credentials(resource_name)
         self.s3_region = self._get_resource_context_param(resource_name, "S3_REGIONNAME")
+        self.s3_protocol = self._get_s3_proto(resource_name)
         boto3_session = boto3.Session(aws_access_key_id = self.s3_accesskey.strip(),
                                    aws_secret_access_key = self.s3_secretkey.strip(),
                                    region_name = self.s3_region.strip())
-        self.boto3_client = boto3_session.client('s3', endpoint_url="https://" + self.s3_hostname)
+        self.endpoint_url = self.s3_protocol + "://" + self.s3_hostname
+        self.boto3_client = boto3_session.client('s3', endpoint_url = self.endpoint_url)
 
 
     def check_object_exists(self, path):
@@ -86,6 +88,11 @@ class S3ResourceInterface(ResourceInterface):
            return hsh.hexdigest()
         else:
            return base64.b64encode(hsh.digest()).decode('ascii')
+
+
+    def _get_s3_proto(self, resource_name):
+        value = self._get_resource_context_param(resource_name, "S3_PROTO")
+        return value.lower() if value is not None else "https"
 
 
     def _get_s3_hostname(self, resource_name):

--- a/ichk/s3_resource_interface.py
+++ b/ichk/s3_resource_interface.py
@@ -1,0 +1,124 @@
+import base64
+import hashlib
+import os
+
+import boto3
+import botocore.exceptions
+
+from irods.models import Resource
+import irods.exception as iexc
+
+from ichk.resource_interface import ResourceInterface
+from ichk.status_codes import Status
+
+class S3ResourceInterface(ResourceInterface):
+    CHUNK_SIZE = 8192
+
+
+    def __init__(self, irods_session, resource_name):
+        self.irods_session = irods_session
+        self.resource_name = resource_name
+        self.s3_hostname = self._get_s3_hostname(resource_name)
+        (self.s3_accesskey, self.s3_secretkey) = self._get_s3_credentials(resource_name)
+        self.s3_region = self._get_resource_context_param(resource_name, "S3_REGIONNAME")
+        boto3_session = boto3.Session(aws_access_key_id = self.s3_accesskey.strip(),
+                                   aws_secret_access_key = self.s3_secretkey.strip(),
+                                   region_name = self.s3_region.strip())
+        self.boto3_client = boto3_session.client('s3', endpoint_url="https://" + self.s3_hostname)
+
+
+    def check_object_exists(self, path):
+        bucket = self._get_bucket_name(path)
+        key = self._get_key_name(path)
+        try:
+            self.boto3_client.head_object(Bucket=bucket, Key=key)
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                return Status.NOT_EXISTING
+            elif e.response['Error']['Code'] == "403":
+                return Status.ACCESS_DENIED
+            else:
+                raise()
+
+        return Status.OK
+
+
+    def _get_bucket_name(self, path):
+        return path.split("/")[1]
+
+
+    def _get_key_name(self, path):
+        return "Vault/" + "/".join(path.split("/")[3:])
+
+
+    def check_coll_exists(self, path):
+        # Collections do not exist separately from objects on S3 resources
+        return Status.UNKNOWN
+
+
+    def get_size(self, path):
+        bucket = self._get_bucket_name(path)
+        key = self._get_key_name(path)
+        object = self.boto3_client.head_object(Bucket=bucket, Key=key)
+        return object["ContentLength"]
+
+
+    def get_checksum(self, path, checksumtype):
+        if checksumtype == "md5":
+            hsh = hashlib.md5()
+        elif checksumtype == "sha2":
+            hsh = hashlib.sha256()
+        else:
+            raise ValueError(f"Checksum type {checksumtype} not supported.")
+
+        bucket = self._get_bucket_name(path)
+        key = self._get_key_name(path)
+
+        with self.boto3_client.get_object(Bucket=bucket, Key=key)["Body"] as stream:
+            while True:
+               chunk = stream.read(S3ResourceInterface.CHUNK_SIZE)
+               if chunk:
+                   hsh.update(chunk)
+               else:
+                   break
+
+        if hsh.name == 'md5':
+           return hsh.hexdigest()
+        else:
+           return base64.b64encode(hsh.digest()).decode('ascii')
+
+
+    def _get_s3_hostname(self, resource_name):
+        return self._get_resource_context_param(resource_name,
+            "S3_DEFAULT_HOSTNAME")
+
+
+    def _get_s3_credentials(self, resource_name):
+        authfile = self._get_resource_context_param(resource_name,
+            "S3_AUTH_FILE")
+
+        if authfile is None:
+            raise Exception(f"Could not find auth file config for S3 resource {resource_name}")
+
+        with open(authfile, "r") as f:
+            accesskey = f.readline()
+            secretkey = f.readline()
+            return (accesskey, secretkey)
+
+
+    def _get_resource_context_param(self, resource_name, param):
+        context = self._get_resource_context(resource_name)
+        for kvpair in context.split(";"):
+            (k, v) = kvpair.split("=")
+            if param == k:
+                return v
+        return None
+
+
+    def _get_resource_context(self, resource_name):
+        try:
+            resource = self.irods_session.query(Resource).filter(
+                Resource.name == resource_name).one()
+        except iexc.NoResultFound:
+            return None
+        return resource[Resource.context]

--- a/ichk/status_codes.py
+++ b/ichk/status_codes.py
@@ -1,0 +1,30 @@
+from enum import Enum
+
+
+class Status(Enum):
+    OK = 0
+    NOT_EXISTING = 1        # File registered in iRODS but not found in vault
+    NOT_REGISTERED = 2      # File found in vault but is not registered in iRODS
+    FILE_SIZE_MISMATCH = 3  # File sizes do not match between database and vault
+    CHECKSUM_MISMATCH = 4   # Checksums do not match between database and vault
+    ACCESS_DENIED = 5       # This script was denied access to the file
+    NO_CHECKSUM = 6         # iRODS has no checksum registered
+    NO_LOCAL_REPLICA = 7    # No replica of data object present on server
+                            # (object list check)
+    NOT_FOUND = 8           # Object not found in iRODS (object list check)
+    REPLICA_NOT_GOOD = 9    # Replica has a state other than GOOD_REPLICA
+    UNKNOWN = 10            # Unknown status (e.g. collection presence on S3 resource)
+
+    def __repr__(self):
+        return self.name
+
+
+class ReplicaStatus(Enum):
+    STALE_REPLICA = 0
+    GOOD_REPLICA = 1
+    INTERMEDIATE_REPLICA = 2
+    READ_LOCKED = 3
+    WRITE_LOCKED = 4
+
+    def __repr__(self):
+        return self.name

--- a/ichk/ufs_resource_interface.py
+++ b/ichk/ufs_resource_interface.py
@@ -1,0 +1,58 @@
+import base64
+import errno
+import hashlib
+import os
+
+from ichk.resource_interface import ResourceInterface
+from ichk.status_codes import Status
+
+class UFSResourceInterface(ResourceInterface):
+    CHUNK_SIZE = 8192
+
+    def check_object_exists(self, path):
+        return self._check_exists(path)
+
+
+    def check_coll_exists(self, path):
+        return self._check_exists(path)
+
+
+    def _check_exists(self, path):
+        try:
+            statinfo = os.stat(path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return Status.NOT_EXISTING
+            elif e.errno == errno.EACCES:
+                return Status.ACCESS_DENIED
+            else:
+                raise
+
+        return Status.OK
+
+
+    def get_size(self, path):
+        return os.stat(path).st_size
+
+
+    def get_checksum(self, path, checksumtype):
+        if checksumtype == "md5":
+            hsh = hashlib.md5()
+        elif checksumtype == "sha2":
+            hsh = hashlib.sha256()
+        else:
+            raise ValueError(f"Checksum type {checksumtype} not supported.")
+
+        f = open(path, 'rb')
+
+        while True:
+           chunk = f.read(UFSResourceInterface.CHUNK_SIZE)
+           if chunk:
+               hsh.update(chunk)
+           else:
+               break
+
+        if hsh.name == 'md5':
+           return hsh.hexdigest()
+        else:
+           return base64.b64encode(hsh.digest()).decode('ascii')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python_irodsclient >= 1.1.0, < 1.2.0
 six
+boto3 == 1.23.10  # Last version that supports Python 3.6

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,9 @@ setup(
     author_email="p.frederiks@uu.nl, l.r.westerhof@uu.nl, s.t.snel@uu.nl, c.j.smeele@uu.nl",
     description=('Check consistency of iRODS database and vault'),
     install_requires=[
-        'six'
         'python-irodsclient >= 1.1.0, < 1.2.0',
+        'six',
+        'boto3 == 1.23.10'
     ],
     name='ichk',
     packages=['ichk', 'irodsutils'],


### PR DESCRIPTION
This adds support for S3 resources in resource and object list modes. Vault mode is not supported (yet) for S3.

The check code has been converted so that it is resource type agnostic. All resource type specific code has been moved to separate resource interface classes. There are currently two implementations: one for unixfilesystem (UFS) and one for S3.